### PR TITLE
Use an io::Cursor instead of tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["fst", "waveform", "wavedump"]
 lz4_flex = "0.11.1"
 flate2 = "1.0"
 num_enum = "0.7.0"
-tempfile = "3"
 thiserror = "1.0.58"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/ekiwi/wellen/issues/25 though presumably this has some RAM usage consequences.

I briefly attempted a `#[cfg(target_arch=wasm)`-specific fix to not change too much, but that would require `#[cfg]-ing` the output of `uncompress_gzip_wrapper` which becomes annoying

I also tried making the return type be `impl Read+Seek` but that requires adding generic arguments in more places.

For now without knowing the performance implications of this, I think it is the best solution