### PR TITLE
Use explicit pattern-match syntax in `reader.rs` to satisfy Clippy

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -501,18 +501,18 @@ impl<R: Read + Seek> HeaderReader<R> {
 
         // incomplete fst files may have start_time and end_time set to 0,
         // in which case we can infer it from the data
-        if let Some(Header {
-            start_time: header_start,
-            end_time: header_end,
-            ..
-        }) = self.header.as_mut()
-            && *header_start == 0
-            && *header_end == 0
-        {
-            *header_end = end_time;
-            if self.data_sections.is_empty() {
-                *header_start = start_time;
+        match self.header.as_mut() {
+            Some(Header {
+                start_time: header_start,
+                end_time: header_end,
+                ..
+            }) if *header_start == 0 && *header_end == 0 => {
+                *header_end = end_time;
+                if self.data_sections.is_empty() {
+                    *header_start = start_time;
+                }
             }
+            _ => (),
         }
 
         self.data_sections.push(info);


### PR DESCRIPTION
Right now, CI in the Protocols repo (e.g. https://github.com/cucapra/protocols/pull/126) fails due to Clippy warning that the `if let Some(Header {...}) = ...` pattern-match in `src/reader.rs` of `fst-reader` uses an unstable Rust feature. This PR changes the `if let Some(...)` into a traditional pattern match to satisfy Clippy.